### PR TITLE
Contributor Badge System: CREDIT.md + Tier-based CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,19 +1,45 @@
 # ZWISERFIT AI Store Manager — Contributors 🌟
 
 > Every contribution matters — code, docs, feedback, ideas, or spreading the word.
+> Non-code contributions see [CREDIT.md](./CREDIT.md)
+> Both? You appear in both files.
 
-## How to get on this list
+---
 
-1. Submit a PR, report a bug, improve docs, or share your thoughts in Issues
-2. Get your contribution acknowledged in a merged PR commit
-3. We'll add you here 🎉
+## 🥇 Founding Contributors
+
+*Angel round contributors who helped define ZWISERFIT's community culture and contribution infrastructure. 🏆 Permanent recognition.*
+
+| Contributor | Contribution | Date | Badge |
+|:-----------|:------------|:----:|:-----:|
+| zp6 | Multi-Bot Identity Architecture (PR #13) | 2026-05-16 | 🏆💻🔧 |
+
+---
+
+## 🥈 Partner
+
+*Active members with 3+ contributions or sustained community engagement.*
+
+| Contributor | Contributions | Active Period | Badge |
+|:-----------|:-------------|:------------:|:-----:|
+| — | — | — | — |
+
+---
+
+## 🥉 Contributor
+
+*Every contributor starts here — file an issue, submit a PR, improve docs.*
+
+| Contributor | Contribution | Date | Badge |
+|:-----------|:------------|:----:|:-----:|
+| — | — | — | — |
 
 ---
 
 ## Core Team
 
 - Shuyu — Ecosystem Command & Architecture
-- Momo — AI Store Manager (in production)
+- Momo — AI Store Manager
 - Tristan — Technical Architecture & Code Review
 - Nova — Digital Asset Strategy & RWA Standards
 - Baron — Brand & Growth
@@ -21,18 +47,6 @@
 - Zeus — Capital & Valuation
 - Stella — Compliance & Audit (Independent)
 - Luna — Global Developer Ecosystem & Community 🌙
-
-## Founding Contributors 🌟
-
-*The first contributors who helped shape ZWISERFIT's community culture and contribution infrastructure.*
-
-- **zp6** 🏆 — Founding Contributor #001. Multi-Bot Identity Architecture (PR #13, merged 2026-05-16). First to help define our contributor reward framework. *(行为资产正在累积)*
-
----
-
-## External Contributors
-
-*(Your name goes here. First PR? First bug? First doc fix? You belong here.)*
 
 ---
 

--- a/CREDIT.md
+++ b/CREDIT.md
@@ -1,0 +1,57 @@
+# ZWISERFIT CREDIT — Non-Code Contributors
+
+> This file recognizes non-code contributions: venue testing, design, translation, evangelism, research, and community support.
+> Code contributors — see [CONTRIBUTORS.md](./CONTRIBUTORS.md)
+> Both? You appear in both files.
+
+---
+
+## 🏆 Founding Contributors
+
+*Angel round contributors who helped define ZWISERFIT's community and contribution culture.*
+
+| Contributor | Contribution | Date | Badge |
+|:-----------|:------------|:----:|:-----:|
+| zp6 | Multi-Bot Identity Architecture (PR #13) | 2026-05-16 | 🏆💻🔧 |
+
+---
+
+## 🤝 Partners
+
+*(Active community members with 3+ contributions across any category)*
+
+| Contributor | Contribution | Active Period | Badge |
+|:-----------|:------------|:------------:|:-----:|
+| — | — | — | — |
+
+---
+
+## 🌟 Contributors
+
+*(Every contribution counts — file your first issue, review a PR, or improve docs)*
+
+| Contributor | Contribution | Date | Badge |
+|:-----------|:------------|:----:|:-----:|
+| — | — | — | — |
+
+---
+
+## Contribution Categories (emoji key)
+
+| Emoji | Type | Description |
+|:----:|:----|:-----------|
+| 💻 | Code | Pull requests, commits |
+| 📖 | Documentation | README, Wiki, API docs |
+| 🐛 | Bug Reports | Issue reporting |
+| 🎨 | Design | UI/UX, branding, visuals |
+| 🌍 | Translation | i18n, localization |
+| 🏪 | Venue Testing | Real-store deployment feedback |
+| 📢 | Talk | Presentations, community events |
+| 💬 | Question | Community support, answering questions |
+| 👀 | Review | Code/documentation review |
+| 🤔 | Ideas | Feature proposals, planning |
+
+---
+
+*ZWISERFIT — Building the open protocol layer for health behavior data assetization.*
+*CREDIT.md v1.0 | 2026-05-24*


### PR DESCRIPTION
## Summary

Introduces a tiered contributor recognition system:
- **CREDIT.md** — new file for non-code contributors
- **CONTRIBUTORS.md** — restructured with 3 tiers (🥇 Founding / 🥈 Partner / 🥉 Contributor)
- All-Contributors emoji-key compatible (💻📖🐛 etc.)

## Changes

| File | Action |
|:----|:------|
| `CREDIT.md` | ✨ New — non-code contributor recognition |
| `CONTRIBUTORS.md` | 📝 Restructured — tier format + emoji badges |

## Background

Drafted from Luna contributor-badge-credit-draft v0.1 (2026-05-24). Part of the contributor retention pipeline following zp6 onboarding (PR #13).

Closes #NA — establishing recognition infrastructure for external contributors.